### PR TITLE
Shift

### DIFF
--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -1,0 +1,21 @@
+require './lib/key'
+require './lib/offset'
+
+class Shift
+
+  attr_reader :key, :offset
+  attr_accessor :a, :b, :c, :d
+
+  def initialize(key, offset)
+    @key = key
+    @offset = offset
+    find_each_shift
+  end
+
+  def find_each_shift
+    @a = key.a + offset.a
+    @b = key.b + offset.b
+    @c = key.c + offset.c
+    @d = key.d + offset.d
+  end
+end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -1,0 +1,29 @@
+require './test/test_helper'
+require 'minitest/autorun'
+require 'minitest/pride'
+require './lib/shift'
+require './lib/key'
+require './lib/offset'
+require 'pry'
+
+class ShiftTest < Minitest::Test
+
+  def test_it_exists
+    key = Key.new
+    offset = Offset.new
+    shift = Shift.new(key, offset)
+    assert_instance_of Shift, shift
+  end
+
+  def test_it_can_find_each_shift
+    key = Key.new("02453")
+    offset = Offset.new("101214")
+    assert_equal "3796", offset.last_four
+    shift = Shift.new(key, offset)
+
+    assert_equal 5, shift.a
+    assert_equal 31, shift.b
+    assert_equal 54, shift.c
+    assert_equal 59, shift.d
+  end
+end


### PR DESCRIPTION
Creates Shift class with respective tests and the following methods:
-initialize(takes a Key and an Offset argument) and calls method find_each_shift
-find_each_shift: adds the Key's ABCD and Offset's ABCD 