### PR TITLE
Refactor of rotation methods

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,9 +1,12 @@
 require './lib/key'
 require './lib/shift'
 require './lib/offset'
+require './lib/rotate'
 require 'pry'
 
 class Enigma
+
+  include Rotate
 
   attr_reader :character_set
 
@@ -29,49 +32,6 @@ class Enigma
 
   def split_message_in_fours(message)
     message.downcase.split('').each_slice(4).to_a
-  end
-
-  def rotate_one_character(char, rotate_by)
-    encoded = ""
-    if !@character_set.include?(char)
-      encoded += char
-    else
-      encoded += @character_set.rotate(rotate_by)[@character_set.index(char)]
-    end
-    encoded
-  end
-
-  def rotate_forward(four_characters_array, shift)
-    encoded = ""
-    four_characters_array.zip(shift.letters).each do |element|
-      encoded += rotate_one_character(element.first, element.last)
-    end
-    encoded
-  end
-
-
-  def rotate_back(four_characters_array, shift)
-    encoded = ""
-    four_characters_array.zip(shift.letters).each do |element|
-      encoded += rotate_one_character(element.first, -element.last)
-    end
-    encoded
-  end
-
-
-
-  def rotate_forward_full_message(given_message, shift)
-    message = split_message_in_fours(given_message)
-    message.map do |set_of_four|
-      rotate_forward(set_of_four,shift)
-    end.join
-  end
-
-  def rotate_back_full_message(given_message, shift)
-    message = split_message_in_fours(given_message)
-    message.map do |set_of_four|
-      rotate_back(set_of_four,shift)
-    end.join
   end
 
   def encrypt(given_message, given_key = nil, given_date = nil)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -41,7 +41,7 @@ class Enigma
     encoded
   end
 
-  def rotate(four_characters_array, shift)
+  def rotate_forward(four_characters_array, shift)
     encoded = ""
     four_characters_array.zip(shift.letters).each do |element|
       encoded += rotate_one_character(element.first, element.last)
@@ -63,7 +63,7 @@ class Enigma
   def rotate_forward_full_message(given_message, shift)
     message = split_message_in_fours(given_message)
     message.map do |set_of_four|
-      rotate(set_of_four,shift)
+      rotate_forward(set_of_four,shift)
     end.join
   end
 

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -31,34 +31,34 @@ class Enigma
     message.downcase.split('').each_slice(4).to_a
   end
 
-  def rotate(four_characters, shift)
+  def rotate(four_characters_array, shift)
     encoded = ""
-    x = four_characters.zip(shift.letters)
-    x.each do |element|
+    four_characters_array.zip(shift.letters).each do |element|
       index_in_alphabet =  @character_set.index(element.first)
       if !@character_set.include?(element.first)
         encoded += element.first
       else
         encoded += @character_set.rotate(element.last)[index_in_alphabet]
-      end #end of if else
-    end.join #end of map
+      end
+    end
     encoded
   end
 
-  def rotate_back(four_characters, shift)
+
+  def rotate_back(four_characters_array, shift)
     encoded = ""
-    x = four_characters.zip(shift.letters)
-    x.each do |element|
+    four_characters_array.zip(shift.letters).each do |element|
       index_in_alphabet =  @character_set.index(element.first)
       if !@character_set.include?(element.first)
         encoded += element.first
       else
         encoded += @character_set.rotate(-element.last)[index_in_alphabet]
-      end #end of if else
-    end.join #end of map
+      end
+    end #end of each
     encoded
   end
-# end
+
+
 
   def rotate_forward_full_message(given_message, shift)
     message = split_message_in_fours(given_message)
@@ -91,46 +91,6 @@ class Enigma
   :date => date.date  }
  end
 
-  # def crack(encrypted_message,date = nil)
-  #   date = create_date(date)
-  #   array_of_chars = split_message_in_fours(encrypted_message)
-  #   last_four = array_of_chars.flatten[-4..-1]
-  #   actual_a_index = @character_set.index(" ")
-  #   actual_b_index = @character_set.index("e")
-  #   actual_c_index = @character_set.index("n")
-  #   actual_d_index = @character_set.index("d")
-  #
-  #   index_a = @character_set.index(last_four[0])
-  #   index_b = @character_set.index(last_four[1])
-  #   index_c = @character_set.index(last_four[2])
-  #   index_d = @character_set.index(last_four[3])
-  #
-  #   shift = Shift.new
-  #
-  #   shift.a = index_a + 1
-  #   shift.b = index_b - actual_b_index
-  #   shift.c = index_c - actual_c_index
-  #   shift.d = index_d - actual_d_index
-  #
-  #   key_a = shift.a - date.a
-  #   key_b = shift.b - date.b
-  #   key_c = shift.c - date.c
-  #   key_d = shift.d - date.d
-  #   binding.pry
-  #
-  #
-  #
-  #
-  #   binding.pry
-    #
-    # last_four.map.with_index do |char,i|
-    #   index_in_alphabet = @character_set.index(char)
-    #   @character_set.index(ends[0])
-    #   binding.pry
-    #   shift.a
-    # end
-
-  # end
 
 
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -31,69 +31,65 @@ class Enigma
     message.downcase.split('').each_slice(4).to_a
   end
 
-  def rotate_forward(given_message, shift)
-    split_message_in_fours(given_message).map do |set_of_four|
-      encoded = ""
-      set_of_four.map.with_index do |char, i|
-        index_in_alphabet = @character_set.index(char)
-        if !@character_set.include?(char)
-          encoded += char
-        else
-          if i == 0
-            encoded += char = @character_set.rotate(shift.a)[index_in_alphabet]
-          elsif i == 1
-            encoded += char = @character_set.rotate(shift.b)[index_in_alphabet]
-          elsif i == 2
-            encoded += char = @character_set.rotate(shift.c)[index_in_alphabet]
-          elsif i == 3
-            encoded += char = @character_set.rotate(shift.d)[index_in_alphabet]
-          end
-        end
-      end
-      encoded
-    end.join
+  def rotate(four_characters, shift)
+    encoded = ""
+    x = four_characters.zip(shift.letters)
+    x.each do |element|
+      index_in_alphabet =  @character_set.index(element.first)
+      if !@character_set.include?(element.first)
+        encoded += element.first
+      else
+        encoded += @character_set.rotate(element.last)[index_in_alphabet]
+      end #end of if else
+    end.join #end of map
+    encoded
+  end
 
+  def rotate_back(four_characters, shift)
+    encoded = ""
+    x = four_characters.zip(shift.letters)
+    x.each do |element|
+      index_in_alphabet =  @character_set.index(element.first)
+      if !@character_set.include?(element.first)
+        encoded += element.first
+      else
+        encoded += @character_set.rotate(-element.last)[index_in_alphabet]
+      end #end of if else
+    end.join #end of map
+    encoded
+  end
+# end
+
+  def rotate_forward_full_message(given_message, shift)
+    message = split_message_in_fours(given_message)
+    message.map do |set_of_four|
+      rotate(set_of_four,shift)
+    end.join
+  end
+
+  def rotate_back_full_message(given_message, shift)
+    message = split_message_in_fours(given_message)
+    message.map do |set_of_four|
+      rotate_back(set_of_four,shift)
+    end.join
   end
 
   def encrypt(given_message, given_key = nil, given_date = nil)
-    date = create_date(given_date)
-    key = create_key(given_key)
-    shift = Shift.new(key,date)
-    {:encryption => rotate_forward(given_message,shift), :key=> key.numbers, :date => date.date  }
+   date = create_date(given_date)
+   key = create_key(given_key)
+   shift = Shift.new(key,date)
+   {:encryption => rotate_forward_full_message(given_message,shift), :key=> key.numbers, :date => date.date  }
   end
 
-  def decrypt(given_message, key, date = nil)
-    key = create_key(key)
-    date = create_date(date)
-    shift = Shift.new(key,date)
-              {:decryption => rotate_back(given_message,shift),
-                :key=> key.numbers,
-                :date => date.date  }
-  end
+ def decrypt(given_message, key, date = nil)
+   key = create_key(key)
+   date = create_date(date)
+   shift = Shift.new(key,date)
 
-  def rotate_back(given_message, shift)
-    split_message_in_fours(given_message).map do |set_of_four|
-      encoded = ""
-      set_of_four.map.with_index do |char, i|
-        index_in_alphabet = @character_set.index(char)
-        if !@character_set.include?(char)
-          encoded += char
-        else
-          if i == 0
-            encoded += char = @character_set.rotate(-shift.a)[index_in_alphabet]
-          elsif i == 1
-            encoded += char = @character_set.rotate(-shift.b)[index_in_alphabet]
-          elsif i == 2
-            encoded += char = @character_set.rotate(-shift.c)[index_in_alphabet]
-          elsif i == 3
-            encoded += char = @character_set.rotate(-shift.d)[index_in_alphabet]
-          end
-        end
-      end
-      encoded
-    end.join
-
-  end
+  {:decryption => rotate_back_full_message(given_message,shift),
+  :key=> key.numbers,
+  :date => date.date  }
+ end
 
   # def crack(encrypted_message,date = nil)
   #   date = create_date(date)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -31,15 +31,20 @@ class Enigma
     message.downcase.split('').each_slice(4).to_a
   end
 
+  def rotate_one_character_and_add_to_encoded(char, rotate_by)
+    encoded = ""
+    if !@character_set.include?(char)
+      encoded += char
+    else
+      encoded += @character_set.rotate(rotate_by)[@character_set.index(char)]
+    end
+    encoded
+  end
+
   def rotate(four_characters_array, shift)
     encoded = ""
     four_characters_array.zip(shift.letters).each do |element|
-      index_in_alphabet =  @character_set.index(element.first)
-      if !@character_set.include?(element.first)
-        encoded += element.first
-      else
-        encoded += @character_set.rotate(element.last)[index_in_alphabet]
-      end
+      encoded += rotate_one_character_and_add_to_encoded(element.first, element.last)
     end
     encoded
   end
@@ -48,13 +53,8 @@ class Enigma
   def rotate_back(four_characters_array, shift)
     encoded = ""
     four_characters_array.zip(shift.letters).each do |element|
-      index_in_alphabet =  @character_set.index(element.first)
-      if !@character_set.include?(element.first)
-        encoded += element.first
-      else
-        encoded += @character_set.rotate(-element.last)[index_in_alphabet]
-      end
-    end #end of each
+      encoded += rotate_one_character_and_add_to_encoded(element.first, -element.last)
+    end
     encoded
   end
 

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -31,7 +31,7 @@ class Enigma
     message.downcase.split('').each_slice(4).to_a
   end
 
-  def rotate_one_character_and_add_to_encoded(char, rotate_by)
+  def rotate_one_character(char, rotate_by)
     encoded = ""
     if !@character_set.include?(char)
       encoded += char
@@ -44,7 +44,7 @@ class Enigma
   def rotate(four_characters_array, shift)
     encoded = ""
     four_characters_array.zip(shift.letters).each do |element|
-      encoded += rotate_one_character_and_add_to_encoded(element.first, element.last)
+      encoded += rotate_one_character(element.first, element.last)
     end
     encoded
   end
@@ -53,7 +53,7 @@ class Enigma
   def rotate_back(four_characters_array, shift)
     encoded = ""
     four_characters_array.zip(shift.letters).each do |element|
-      encoded += rotate_one_character_and_add_to_encoded(element.first, -element.last)
+      encoded += rotate_one_character(element.first, -element.last)
     end
     encoded
   end

--- a/lib/rotate.rb
+++ b/lib/rotate.rb
@@ -1,0 +1,42 @@
+module Rotate
+
+    def rotate_one_character(char, rotate_by)
+      encoded = ""
+      if !@character_set.include?(char)
+        encoded += char
+      else
+        encoded += @character_set.rotate(rotate_by)[@character_set.index(char)]
+      end
+      encoded
+    end
+
+    def rotate_forward(four_characters_array, shift)
+      encoded = ""
+      four_characters_array.zip(shift.letters).each do |element|
+        encoded += rotate_one_character(element.first, element.last)
+      end
+      encoded
+    end
+
+    def rotate_back(four_characters_array, shift)
+      encoded = ""
+      four_characters_array.zip(shift.letters).each do |element|
+        encoded += rotate_one_character(element.first, -element.last)
+      end
+      encoded
+    end
+
+    def rotate_forward_full_message(given_message, shift)
+      message = split_message_in_fours(given_message)
+      message.map do |set_of_four|
+        rotate_forward(set_of_four,shift)
+      end.join
+    end
+
+    def rotate_back_full_message(given_message, shift)
+      message = split_message_in_fours(given_message)
+      message.map do |set_of_four|
+        rotate_back(set_of_four,shift)
+      end.join
+    end
+end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -8,12 +8,14 @@ class Shift
               :a,
               :b,
               :c,
-              :d
+              :d,
+              :letters
 
   def initialize(key = nil, offset = nil)
     @key = key
     @offset = offset
     find_each_shift
+    @letters = [@a,@b,@c,@d]
   end
 
   def find_each_shift

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -79,6 +79,15 @@ class EnigmaTest < Minitest::Test
 
   end
 
+  def test_it_can_rotate_one_character
+
+    enigma = Enigma.new
+
+    assert_equal "c", enigma.rotate_one_character("a", 2)
+    assert_equal "!", enigma.rotate_one_character("!", 5)
+    assert_equal " ", enigma.rotate_one_character(" ", 27)
+  end
+
   def test_it_can_rotate_forward_a_message_by_n_characters
 
     enigma = Enigma.new

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -89,7 +89,7 @@ class EnigmaTest < Minitest::Test
     message = "abcd"
     expected = "qzpi"
 
-    assert_equal expected, enigma.rotate_forward(message, shift)
+    assert_equal expected, enigma.rotate_forward_full_message(message, shift)
   end
 
   def test_it_can_decrypt_a_message
@@ -116,7 +116,7 @@ class EnigmaTest < Minitest::Test
     expected = "abcd"
     message = "qzpi"
 
-    assert_equal expected, enigma.rotate_back(message,shift)
+    assert_equal expected, enigma.rotate_back(message.split(''),shift)
   end
 
   def test_rotate_back_also_returns_special_characters_as_themselves
@@ -129,7 +129,7 @@ class EnigmaTest < Minitest::Test
     message = "qzp!"
     expected = "abc!"
 
-    assert_equal expected, enigma.rotate_back(message,shift)
+    assert_equal expected, enigma.rotate_back(message.split(''),shift)
 
   end
 
@@ -138,6 +138,8 @@ class EnigmaTest < Minitest::Test
     enigma = Enigma.new
     encrypted = enigma.encrypt("hello world", "02715")
     today = Date.today.strftime("%d%m%y")
+
+
     expected = {
                 :encryption => "nfhauasdxm ",
                 :key =>  "02715",


### PR DESCRIPTION
I created a Module called Rotate to hold all the rotation methods that were in Enigma.

#### Helper methods:

 **-rotate_one_character(char, rotate_by).** The first argument is the letter and the second argument is how much it should rotate it by. If the letter is a special argument, it just returns it. Otherwise, it rotates the letter in the alphabet by the second argument.
**-rotate_forward:** takes an array of four characters and a shift. It uses the above method to rotate them
**-rotate_back:** does the same, but rotates them backwards.
**-rotate_forward_full_message:** Takes a string (not an array) and a shift. Uses rotate_forward to rotate each set of four characters
**-rotate_back_full_message:** Does the same as above, but rotates them backwards.